### PR TITLE
Emiliano Sala search team recover body from plane wreckage

### DIFF
--- a/okk65
+++ b/okk65
@@ -1,0 +1,15 @@
+The Air Accidents Investigation Branch said specialist contractors joined the operation in "challenging conditions".
+
+It was carried out in "as dignified a way as possible" and the m
+Mr Ibbotson, 59, from Crowle, North Lincolnshire, was at the controls when the flight lost contact with air traffic controllers on 21 January.en's families were kept updated throughout, it said.
+
+The wreckage of the plane, which vanished two weeks ago over the English Channel, had been found off Guernsey.
+
+The Piper Malibu N264DB was en route from France to Cardiff, after the 28-year-old Argentine striker made a quick trip back to his former club Nantes two days after his £15m transfer to Cardiff was announced.
+
+
+The body that was recovered from the wreckage was being taken to the Isle of Portland to be passed to the Dorset coroner. No details have been released concerning its identification.
+
+An official search was called off on 24 January after Guernsey's harbour master said the chances of survival were "extremely remote".
+
+However, the wreckage was located thanks to a privately funded operation led by marine scientist and oceanographer David Mearns. He called in the Air Accidents Investigation Branch after using sonar and a submersible device fitted with cameras to confirm it was the plane.


### PR DESCRIPTION
Investigation Branch said specialist contractors joined the operation in "challenging conditions".

It was carried out in "as dignified a way as possible" and the men's families were kept updated throughout, it said.

The wreckage of the plane, which vanished two weeks ago [바카라](https://www.xn--o79ak1s1tdy0owni.kr/)over the English Channel, had been found off Guernsey.

The Piper Malibu N264DB was en route from France to Cardiff, after the 28-year-old Argentine striker made a quick trip back to his former club Nantes two days after his £15m transfer to Cardiff was announced.

Mr Ibbotson, 59, from Crowle, North Lincolnshire, was at the controls when the flight lost contact with air traffic controllers on 21 January.

The body that was recovered from the wreckage was being taken to the Isle of Portland to be passed to the Dorset coroner. No details have been released concerning its identification.

An official search was called off on 24 January after Guernsey's harbour master said the chances of survival were "extremely remote".

However, the wreckage was located thanks to a privately funded operation led by marine scientist and oceanographer David Mearns. He called in the Air Accidents Investigation Branch after using sonar and a submersible device fitted with cameras to confirm it was the plane.